### PR TITLE
Add support for 1.0.18

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ set -eo pipefail
 
 ### Constants
 
-VERSION=1.0.17
+VERSION=1.0.18
 SODIUM_DIR=libsodium-$VERSION
 TARBALL=$SODIUM_DIR.tar.gz
 TARBALL_URL=https://download.libsodium.org/libsodium/releases/$TARBALL


### PR DESCRIPTION
Libsodium deprecated 1.0.17 on May 22nd, and moved the source of 1.0.17 to the \old\ directory (https://download.libsodium.org/libsodium/releases/old/>